### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ By default the module will pull the Subnet Router Docker image from [cocallaw/ta
 ```bash
 docker build \
   --tag tailscale-subnet-router:v1 \
-  --file ./docker/tailscale.Dockerfile \
+  --file Dockerfile \
   .
 
 # Optionally override the tag for the base `tailscale/tailscale` image


### PR DESCRIPTION
Command to build docker locally should refer to correct file and should be assumed to be run from the same directory as the entrypoint script.

Alternatively, could rename Dockerfile to tailscale.Dockerfile and could change "COPY tailscale-entrypoint.sh" to account for subfolder.

