### PR TITLE
replace network profile id with subnet ids

### DIFF
--- a/aci.tf
+++ b/aci.tf
@@ -27,7 +27,7 @@ resource "azurerm_container_group" "containergroup" {
   resource_group_name = var.resource_group_name
   ip_address_type     = "Private"
   os_type             = "Linux"
-  network_profile_id  = azurerm_network_profile.acg_network_profile.id
+  subnet_ids          = [data.azurerm_subnet.subnet.id]
 
   container {
     name   = var.container_name


### PR DESCRIPTION
With azurerm providers v3.16.0 and newer, network_profile_id is deprecated. Testing today with v3.51.0, there is an error and the container group does not succeed:

`Failure sending request: StatusCode=0 -- Original Error: Code="PrivateIpWithoutSubnetNotSupported" Message="IP Address type in container group 'mycontainergroup' is invalid. Private IP address is only supported when a subnet ID is defined."`

Per the information below, one option is to use subnet_ids. A change to use subnet_ids is what is contained in this PR.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_group

_network_profile_id is [deprecated](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-vnet) by Azure. For users who want to continue to manage existing azurerm_container_group that rely on network_profile_id, please stay on provider versions prior to v3.16.0. Otherwise, use subnet_ids instead._